### PR TITLE
fix(importer): construct PalettedContainer codecs instead of leaving them null

### DIFF
--- a/src/main/java/me/cortex/voxy/commonImpl/importers/WorldImporter.java
+++ b/src/main/java/me/cortex/voxy/commonImpl/importers/WorldImporter.java
@@ -68,8 +68,8 @@ public class WorldImporter implements IDataImporter {
         this.world = worldEngine;
         this.service = sm.createService(()->new Pair<>(()->this.jobQueue.poll().run(), ()->{}), 3, "World importer", runChecker);
 
-        var biomeRegistry = mcWorld.registryAccess().lookupOrThrow(Registries.BIOME);
-        var defaultBiome = biomeRegistry.getOrThrow(Biomes.PLAINS);
+        var biomeRegistry = mcWorld.registryAccess().registryOrThrow(Registries.BIOME);
+        var defaultBiome = biomeRegistry.getHolderOrThrow(Biomes.PLAINS);
         this.defaultBiomeProvider = new PalettedContainerRO<>() {
             @Override
             public Holder<Biome> get(int x, int y, int z) {
@@ -114,10 +114,16 @@ public class WorldImporter implements IDataImporter {
             }
         };
 
-        // MC 1.21.1: PalettedContainerFactory removed - need to find correct codec creation API
-        // TODO: Fix codec creation for PalettedContainer in MC 1.21.1
-        this.biomeCodec = null; // Placeholder
-        this.blockStateCodec = null; // Placeholder
+        this.blockStateCodec = PalettedContainer.codecRW(
+                Block.BLOCK_STATE_REGISTRY,
+                BlockState.CODEC,
+                PalettedContainer.Strategy.SECTION_STATES,
+                Blocks.AIR.defaultBlockState());
+        this.biomeCodec = PalettedContainer.codecRO(
+                biomeRegistry.asHolderIdMap(),
+                biomeRegistry.holderByNameCodec(),
+                PalettedContainer.Strategy.SECTION_BIOMES,
+                defaultBiome);
     }
 
 


### PR DESCRIPTION
## Summary
- Fix `WorldImporter` NPE on every imported chunk: replace `null` placeholder codecs with the vanilla `PalettedContainer.codecRW` / `codecRO` recipe used in `ChunkSerializer`.
- Switch the biome registry lookup from `lookupOrThrow` (`HolderLookup`) to `registryOrThrow` (`Registry`) so `asHolderIdMap()` and `holderByNameCodec()` are reachable.

## Why
The 1.21.11 → 1.21.1 port commit (13b3de7f) intentionally left `biomeCodec` and `blockStateCodec` as `null` placeholders with a TODO ("PalettedContainerFactory removed - need to find correct codec creation API"). `PalettedContainerFactory` was added in 1.21.11 and doesn't exist in 1.21.1; vanilla constructs the codecs inline in `ChunkSerializer`, so this PR mirrors that recipe.

Without the fix, `importSectionNBT` NPEs on `blockStateCodec.parse(...)` for every chunk, the exception is swallowed by the surrounding try/catch in `importChunkNBT`, and the log fills with `Exception importing world chunk: java.lang.NullPointerException` from every Chunk Render Task Executor thread while zero chunks actually import.

## Test plan
- [x] `./gradlew build` passes locally
- [x] Tested in-game on **Arch Linux** with the [Create: Colonies & Aeronautics](https://www.curseforge.com/minecraft/modpacks/create-colonies-aeronautics) modpack: NPE flood gone, chunks import as expected.