### PR TITLE
build: fix Gradle deprecation and add JDK 21 toolchain auto-provisioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,8 @@ repositories {
     exclusiveContent {
         forRepository {
             maven {
-                name "caffeinemcRepository"
-                url "https://maven.caffeinemc.net/snapshots"
+                name = "caffeinemcRepository"
+                url = "https://maven.caffeinemc.net/snapshots"
             }
         }
         filter {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,3 +7,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}


### PR DESCRIPTION
## Summary
- Switch caffeinemc repository `name`/`url` in `build.gradle` to explicit `=` assignment. Groovy space-assignment is deprecated and scheduled for removal in Gradle 10.
- Add Foojay Toolchains plugin to `settings.gradle` so Gradle can auto-provision JDK 21 when only older JDKs are installed.

## Test plan
- [ ] `./gradlew build` succeeds on a fresh machine with no JDK 21 pre-installed
- [ ] `build/reports/problems/problems-report.html` no longer lists the two Groovy space-assignment deprecation warnings on lines 77–78 of `build.gradle`