### PR TITLE
Support Sodium 0.8 alongside 0.6.13 (Create 6 / Sable 2.x packs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Before modifying any file:
 **Current validated versions** (for NeoForge 1.21.1):
 - NeoForge: 21.1.217
 - Minecraft: 1.21.1
-- Sodium: mc1.21.1-0.6.13-neoforge
+- Sodium: mc1.21.1-0.6.13-neoforge (runtime also supports the 0.8.x line; build compiles against 0.6.13)
 - Lithium: mc1.21.1-0.15.1-neoforge
 - Forgified Fabric API: Check Modrinth/CurseForge for correct 1.21.1 version
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You might wonder: "Why not just use the Fabric version with [Sinytra Connector](
 - Delayed chunk unloading to prevent pop-out effects
 
 ### Current Limitations
-- Requires Sodium 0.6.13+ (NeoForge version)
+- Requires Sodium 0.6.13 or newer (NeoForge version); both the 0.6.x and 0.8.x Sodium lines are supported
 - Some optional integrations not yet ported (Iris, Nvidium, Vivecraft)
 - Debug screen integration disabled (MC 1.21.1 API changes)
 
@@ -59,7 +59,7 @@ You might wonder: "Why not just use the Fabric version with [Sinytra Connector](
 |------------|---------|------|
 | Minecraft | 1.21.1 | - |
 | NeoForge | 21.1.x | [NeoForge](https://neoforged.net/) |
-| Sodium | mc1.21.1-0.6.13-neoforge | [Modrinth](https://modrinth.com/mod/sodium/version/mc1.21.1-0.6.13-neoforge) |
+| Sodium | mc1.21.1-0.6.13-neoforge or the 0.8.x line | [Modrinth](https://modrinth.com/mod/sodium/versions?g=1.21.1&l=neoforge) |
 | Forgified Fabric API | 0.116.7+2.2.0+1.21.1 | [Modrinth](https://modrinth.com/mod/forgified-fabric-api/version/0.116.7+2.2.0+1.21.1) |
 
 ### Recommended Dependencies

--- a/TESTING.md
+++ b/TESTING.md
@@ -42,7 +42,7 @@ In the Java settings, add these JVM arguments for better performance:
 
 ### 2.1 Download Sodium for NeoForge
 
-Voxy requires **Sodium 0.6.9 or later** for NeoForge 1.21.1:
+Voxy requires **Sodium 0.6.13 or later** for NeoForge 1.21.1 (both the 0.6.x and 0.8.x lines work):
 
 1. Go to [Modrinth Sodium page](https://modrinth.com/mod/sodium) or [CurseForge Sodium page](https://www.curseforge.com/minecraft/mc-mods/sodium)
 2. Download the **NeoForge 1.21.1** compatible version (0.6.9+)
@@ -83,7 +83,7 @@ build/libs/voxy-0.2.9-alpha.jar
 ### 3.3 Verify Dependencies
 
 Ensure the following mods are installed and enabled:
-- ✅ **Sodium** (0.6.9+)
+- ✅ **Sodium** (0.6.13+, 0.8.x also supported)
 - ✅ **Voxy** (0.2.9-alpha)
 
 ## Step 4: Launch Configuration

--- a/src/main/java/me/cortex/voxy/Voxy.java
+++ b/src/main/java/me/cortex/voxy/Voxy.java
@@ -48,6 +48,11 @@ public class Voxy {
         }
 
         try {
+            // SodiumOptionsAPI (and our page behind it) target Sodium 0.6's options GUI.
+            // Probe for it first: on Sodium 0.8+ those classes are gone, and registering
+            // anyway would defer the NoClassDefFoundError to when the Video Settings
+            // screen opens - outside any of our try/catch blocks.
+            Class.forName("net.caffeinemc.mods.sodium.client.gui.options.OptionPage");
             // Load and invoke the integration class only when we know the API is present
             // This prevents NoClassDefFoundError when SodiumOptionsAPI is not installed
             Class<?> sodiumOptionsClass = Class.forName("me.cortex.voxy.client.config.VoxySodiumOptions");

--- a/src/main/java/me/cortex/voxy/client/core/gl/shader/ShaderLoader.java
+++ b/src/main/java/me/cortex/voxy/client/core/gl/shader/ShaderLoader.java
@@ -1,12 +1,15 @@
 package me.cortex.voxy.client.core.gl.shader;
 
 
+import me.cortex.voxy.common.Logger;
 import net.caffeinemc.mods.sodium.client.gl.shader.ShaderConstants;
 import net.caffeinemc.mods.sodium.client.gl.shader.ShaderParser;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -25,6 +28,43 @@ import java.util.regex.Pattern;
  */
 public class ShaderLoader {
     private static final Pattern IMPORT_PATTERN = Pattern.compile("#import <(?<namespace>.*):(?<path>.*)>");
+
+    // Sodium 0.8 changed ShaderParser.parseShader's return type from String to the
+    // ParsedShader record (same parameters, source now behind .src()). Resolve the
+    // method reflectively so one build runs on both Sodium 0.6.x and 0.8.x.
+    private static final MethodHandle PARSE_SHADER;
+    private static final MethodHandle PARSED_SHADER_SRC; // non-null only on Sodium 0.8+
+
+    static {
+        MethodHandle parse;
+        MethodHandle src = null;
+        try {
+            var method = ShaderParser.class.getMethod("parseShader", String.class, ShaderConstants.class);
+            parse = MethodHandles.lookup().unreflect(method);
+            if (method.getReturnType() != String.class) {
+                src = MethodHandles.lookup().unreflect(method.getReturnType().getMethod("src"));
+            }
+        } catch (ReflectiveOperationException e) {
+            // Log before throwing: later touches of this class throw NoClassDefFoundError
+            // without the cause, so this line is the one durable diagnostic.
+            Logger.error("Failed to resolve Sodium's ShaderParser.parseShader - incompatible Sodium version?", e);
+            throw new ExceptionInInitializerError(e);
+        }
+        PARSE_SHADER = parse;
+        PARSED_SHADER_SRC = src;
+    }
+
+    /** Calls Sodium's shader preprocessor, unwrapping the 0.8 ParsedShader record when present. */
+    private static String parseWithSodium(String source, ShaderConstants constants) {
+        try {
+            Object out = PARSE_SHADER.invoke(source, constants);
+            return PARSED_SHADER_SRC == null ? (String) out : (String) PARSED_SHADER_SRC.invoke(out);
+        } catch (RuntimeException | Error e) {
+            throw e; // preserve pre-patch propagation exactly
+        } catch (Throwable t) {
+            throw new RuntimeException("Sodium shader preprocessing failed", t);
+        }
+    }
 
     /**
      * Parse and load a shader, matching upstream Voxy behavior.
@@ -49,7 +89,7 @@ public class ShaderLoader {
         String processed = "\n" + shaderSource + "\n//beans";
 
         // Apply Sodium's shader constants processing (handles #define etc.)
-        processed = ShaderParser.parseShader(processed, ShaderConstants.builder().build());
+        processed = parseWithSodium(processed, ShaderConstants.builder().build());
 
         // Normalize line endings and strip original #version (upstream behavior)
         processed = processed.replaceAll("\r\n", "\n");

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinDefaultChunkRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinDefaultChunkRenderer.java
@@ -20,6 +20,7 @@ import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Group;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
@@ -30,10 +31,34 @@ public abstract class MixinDefaultChunkRenderer extends ShaderChunkRenderer {
         super(device, vertexType);
     }
 
-    // Sodium 0.6.13: render signature is (ChunkRenderMatrices, CommandList, ChunkRenderListIterable, TerrainRenderPass, CameraTransform)
-    // boolean indexedRenderingEnabled parameter removed in Sodium 0.6.x
-    @Inject(method = "render", at = @At(value = "HEAD"), cancellable = true)
+    // The render signature differs between Sodium generations:
+    //   0.6.x: (ChunkRenderMatrices, CommandList, ChunkRenderListIterable, TerrainRenderPass, CameraTransform)
+    //   0.8.x: same + trailing boolean indexedRenderingEnabled (restored)
+    // One descriptor-qualified variant per shape and injection point, require = 0 each;
+    // the @Groups make "exactly one applied" per pair a hard invariant, so an unknown
+    // future Sodium fails loudly at apply time instead of silently dropping the LOD pass.
+    // NOTE: descriptor qualification relies on Mixin's strict selector pass; never run
+    // with -Dmixin.env.remapRefMap=true (the permissive pass matches by name only and
+    // would bind the wrong variant).
+    @Unique
+    private static final String RENDER_SODIUM_06 = "render(Lnet/caffeinemc/mods/sodium/client/render/chunk/ChunkRenderMatrices;Lnet/caffeinemc/mods/sodium/client/gl/device/CommandList;Lnet/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderListIterable;Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;Lnet/caffeinemc/mods/sodium/client/render/viewport/CameraTransform;)V";
+    @Unique
+    private static final String RENDER_SODIUM_08 = "render(Lnet/caffeinemc/mods/sodium/client/render/chunk/ChunkRenderMatrices;Lnet/caffeinemc/mods/sodium/client/gl/device/CommandList;Lnet/caffeinemc/mods/sodium/client/render/chunk/lists/ChunkRenderListIterable;Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;Lnet/caffeinemc/mods/sodium/client/render/viewport/CameraTransform;Z)V";
+
+    @Group(name = "voxy$dcrHead", min = 1, max = 1)
+    @Inject(method = RENDER_SODIUM_06, at = @At(value = "HEAD"), cancellable = true, require = 0)
     private void cancelThingie(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, CallbackInfo ci) {
+        this.voxy$replaceRender(matrices, renderPass, camera, ci);
+    }
+
+    @Group(name = "voxy$dcrHead", min = 1, max = 1)
+    @Inject(method = RENDER_SODIUM_08, at = @At(value = "HEAD"), cancellable = true, require = 0)
+    private void cancelThingieSodium08(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, boolean indexedRenderingEnabled, CallbackInfo ci) {
+        this.voxy$replaceRender(matrices, renderPass, camera, ci);
+    }
+
+    @Unique
+    private void voxy$replaceRender(ChunkRenderMatrices matrices, TerrainRenderPass renderPass, CameraTransform camera, CallbackInfo ci) {
         if (VoxyClient.disableSodiumChunkRender()) {
             super.begin(renderPass);
             this.doRender(matrices, renderPass, camera);
@@ -42,8 +67,15 @@ public abstract class MixinDefaultChunkRenderer extends ShaderChunkRenderer {
         }
     }
 
-    @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/ShaderChunkRenderer;end(Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;)V", shift = At.Shift.BEFORE))
+    @Group(name = "voxy$dcrTail", min = 1, max = 1)
+    @Inject(method = RENDER_SODIUM_06, at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/ShaderChunkRenderer;end(Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;)V", shift = At.Shift.BEFORE), require = 0)
     private void injectRender(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, CallbackInfo ci) {
+        this.doRender(matrices, renderPass, camera);
+    }
+
+    @Group(name = "voxy$dcrTail", min = 1, max = 1)
+    @Inject(method = RENDER_SODIUM_08, at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/render/chunk/ShaderChunkRenderer;end(Lnet/caffeinemc/mods/sodium/client/render/chunk/terrain/TerrainRenderPass;)V", shift = At.Shift.BEFORE), require = 0)
+    private void injectRenderSodium08(ChunkRenderMatrices matrices, CommandList commandList, ChunkRenderListIterable renderLists, TerrainRenderPass renderPass, CameraTransform camera, boolean indexedRenderingEnabled, CallbackInfo ci) {
         this.doRender(matrices, renderPass, camera);
     }
 

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderRegionManager.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderRegionManager.java
@@ -17,7 +17,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = RenderRegionManager.class, remap = false)
 public class MixinRenderRegionManager {
-    @Redirect(method = "uploadResults(Lnet/caffeinemc/mods/sodium/client/gl/device/CommandList;Lnet/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion;Ljava/util/Collection;)V", at = @At(value = "INVOKE", target = "Ljava/lang/Math;toIntExact(J)I"), remap = false)
+    // NOTE: this mixin is not listed in client.voxy.mixins.json. Its redirect target
+    // (Math.toIntExact inside uploadResults) exists in neither Sodium 0.6.13 nor 0.8.12,
+    // so require = 0 keeps it from hard-failing if it is ever wired back in.
+    @Redirect(method = "uploadResults(Lnet/caffeinemc/mods/sodium/client/gl/device/CommandList;Lnet/caffeinemc/mods/sodium/client/render/chunk/region/RenderRegion;Ljava/util/Collection;)V", at = @At(value = "INVOKE", target = "Ljava/lang/Math;toIntExact(J)I"), remap = false, require = 0)
     private int voxy$cancelFade(long time) {
         var vrs = ((IGetVoxyRenderSystem)(Minecraft.getInstance().levelRenderer)).getVoxyRenderSystem();
         if (vrs!=null) {

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderSectionManager.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinRenderSectionManager.java
@@ -24,6 +24,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Group;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -37,10 +38,26 @@ public class MixinRenderSectionManager {
 
     @Shadow @Final private ChunkBuilder builder;
 
-    // Sodium 0.6.13: Constructor signature is (ClientLevel, int, CommandList)
-    // SortBehavior parameter removed in Sodium 0.6.x
-    @Inject(method = "<init>", at = @At("TAIL"))
+    // The constructor signature differs between Sodium generations:
+    //   0.6.x: (ClientLevel, int, CommandList)
+    //   0.8.x: (ClientLevel, int, SortBehavior, CommandList)  (SortBehavior restored)
+    // One descriptor-qualified variant per shape, require = 0 each; the @Group makes
+    // "exactly one applied" a hard invariant, so an unknown future Sodium fails loudly
+    // at apply time instead of silently leaving bottomSectionY at 0.
+    @Group(name = "voxy$rsmCtor", min = 1, max = 1)
+    @Inject(method = "<init>(Lnet/minecraft/client/multiplayer/ClientLevel;ILnet/caffeinemc/mods/sodium/client/gl/device/CommandList;)V", at = @At("TAIL"), require = 0)
     private void voxy$resetChunkTracker(ClientLevel level, int renderDistance, CommandList commandList, CallbackInfo ci) {
+        this.voxy$onConstructed(level);
+    }
+
+    @Group(name = "voxy$rsmCtor", min = 1, max = 1)
+    @Inject(method = "<init>(Lnet/minecraft/client/multiplayer/ClientLevel;ILnet/caffeinemc/mods/sodium/client/render/chunk/translucent_sorting/SortBehavior;Lnet/caffeinemc/mods/sodium/client/gl/device/CommandList;)V", at = @At("TAIL"), require = 0)
+    private void voxy$resetChunkTrackerSodium08(ClientLevel level, int renderDistance, SortBehavior sortBehavior, CommandList commandList, CallbackInfo ci) {
+        this.voxy$onConstructed(level);
+    }
+
+    @Unique
+    private void voxy$onConstructed(ClientLevel level) {
         if (level.levelRenderer != null) {
             var system = ((IGetVoxyRenderSystem)(level.levelRenderer)).getVoxyRenderSystem();
             if (system != null) {


### PR DESCRIPTION
Current Create packs (Create 6 with Create Aeronautics, Offroad, Simulated) depend on Sable 2.x, which requires Sodium 0.8.12+. Since this port needs Sodium 0.6.13, Voxy could not run in those packs at all. This PR makes one jar run on **both** Sodium lines.

PR #50 solves the same Sodium incompatibility as a hard switch to 0.8, this PR is compat-only and keeps 0.6.13 working as well.

I checked every `net.caffeinemc` reference in the codebase against both Sodium jars, member by member. Only three things break between 0.6.13 and 0.8.12:

* `ShaderParser.parseShader` returns a `ParsedShader` record in 0.8 instead of a `String` (a `NoSuchMethodError` at runtime today). Resolved once through a `MethodHandle` and unwrapped with `.src()` on 0.8. Sodium 0.9.1 keeps this shape, so it also covers the next line.
* `RenderSectionManager`'s constructor regained the `SortBehavior` parameter, so the ctor inject's arg capture no longer matches. Replaced with two descriptor-qualified variants (`require = 0`) in a `@Group(min = 1, max = 1)`, so exactly one applies and an unknown future Sodium fails loudly instead of silently.
* `DefaultChunkRenderer.render` regained the trailing `boolean`. Same treatment for both injection points.

Two small hardenings in the same area: the SodiumOptionsAPI page registration now probes for Sodium 0.6's `OptionPage` first (on 0.8 the old options GUI is gone, and the failure would otherwise fire when the settings screen opens, outside any try/catch), and the unlisted `MixinRenderRegionManager` redirect gets `require = 0` since its target exists in neither Sodium line. README and TESTING now mention both lines.

The declared sodium range is already `[0.6.13,)`, so no metadata change is needed.

Tested at runtime on both Sodium lines:

* Sodium 0.8.12-beta.1 in a Create Aeronautics pack on NeoForge 21.1.248 with Sable 2.0.1: no crash, LODs render correctly.
* Sodium 0.6.13 regression check in a minimal instance (this port + Sodium 0.6.13 + Forgified Fabric API, joined a dedicated server): behaves exactly as before the patch, LODs render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)